### PR TITLE
Change anchor tags to Link in Navbar

### DIFF
--- a/src/components/Navbar/Navbar.js
+++ b/src/components/Navbar/Navbar.js
@@ -29,16 +29,16 @@ export default function Navbar({ handlesetsearch, handlesetcategoryvalue, handle
           <div class="collapse navbar-collapse" id="navbarTogglerDemo01">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0 justify-content-evenly" style={{ paddingLeft: '1rem', paddingRight: '1rem', width:"100%" }}>
               <li className="nav-item">
-                <a class="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue} >Women's clothing</a>
+                <Link className="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue} >Women's clothing</Link>
               </li>
               <li class="nav-item">
-                <a class="nav-link fs-5 p-1 px-5 smnvit" aria-current="page" onClick={handlesetcategoryvalue}>Men's clothing</a>
+                <Link className="nav-link fs-5 p-1 px-5 smnvit" aria-current="page" onClick={handlesetcategoryvalue}>Men's clothing</Link>
               </li>
               <li class="nav-item">
-                <a class="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue}>Jewelery</a>
+                <Link className="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue}>Jewelery</Link>
               </li>
               <li class="nav-item">
-                <a class="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue}>Electronics</a>
+                <Link className="nav-link fs-5 p-1 px-5 smnvit" onClick={handlesetcategoryvalue}>Electronics</Link>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Fixes #27 

Changes
1. Updated `<a>` to `<Link>` in `Navbar.js`
2. Renamed `class` to `className` in `Navbar.js`

Screenshot
![image](https://github.com/arpittyagirocks/Humari-Dukan/assets/17562944/cfe26bef-35e3-475f-b57c-e5e2181257ee)
